### PR TITLE
Search query builer tweaks

### DIFF
--- a/app/controllers/search-query-builder.js
+++ b/app/controllers/search-query-builder.js
@@ -45,7 +45,7 @@ export default Ember.Controller.extend({
     aggregates:[],
     queryFilters:[],
     queryFilterOperators:["AND", "OR", "NOT"],
-    profileQueryParameter: true,
+    profileQueryParameter: false,
     returnFields:["guid"],
     url: computed('searchType', 'profileQueryParameter', function() {
         let type = this.get('searchType');

--- a/app/controllers/search-query-builder.js
+++ b/app/controllers/search-query-builder.js
@@ -96,7 +96,7 @@ export default Ember.Controller.extend({
                             'queryFilters.@each.operator','queryFilters.@each.value','queryFilters.@each.startValue',
                             'queryFilters.@each.endValue','sort','pageSize','pageNumber','getUsers','getGroups',
                             'getLocations', 'aggregates', 'aggregates.@each', 'aggregates.@each.field', 'aggregates.@each.type',
-                            'aggregates.@each.name', 'aggregates.@each.value', 'returnFields', 'profileQueryParameter', function() {
+                            'aggregates.@each.name', 'aggregates.@each.value', 'returnFields.@each', 'profileQueryParameter', function() {
         this._calculateQueryJson();
         this._setAvailableFilterFields();
         this._setSearchTypeUrls();

--- a/app/controllers/search-query-builder.js
+++ b/app/controllers/search-query-builder.js
@@ -18,12 +18,12 @@ export default Ember.Controller.extend({
         {
             name: "General search",
             id:"general_search",
-            url:"/api/v2/search?profile=true"
+            url:"/api/v2/search"
         },
         {
             name: "Suggest",
             id:"suggest",
-            url:"/api/v2/search/suggest?profile=true"
+            url:"/api/v2/search/suggest"
         }
     ],
     queryTypes:[
@@ -143,9 +143,9 @@ export default Ember.Controller.extend({
     _setSearchTypeUrls(){
         for (let x=0; x< this.searchTypes.length; x++){
             if (this.searchTypes[x].id === "general_search") {
-                this.searchTypes[x].url = "/api/v2/search?profile=" + this.profileQueryParameter;
+                this.searchTypes[x].url = this.profileQueryParameter ? "/api/v2/search" : "/api/v2/search?profile=false";
             } else if (this.searchTypes[x].id === "suggest") {
-                this.searchTypes[x].url = "/api/v2/search/suggest?profile=" + this.profileQueryParameter;
+                this.searchTypes[x].url = this.profileQueryParameter ? "/api/v2/search/suggest" : "/api/v2/search/suggest?profile=false";
             }
         }
     },

--- a/app/controllers/search-query-builder.js
+++ b/app/controllers/search-query-builder.js
@@ -11,20 +11,19 @@ export default Ember.Controller.extend({
     getUsers: true,
     getGroups: true,
     getLocations: true,
-    getChats: false,
     sortOptions:["ASC", "DESC", "SCORE"],
-    sort: "ASC",
+    sort: "SCORE",
     searchType: 'general_search',
     searchTypes:[
         {
             name: "General search",
             id:"general_search",
-            url:"/api/v2/search?profile=false"
+            url:"/api/v2/search?profile=true"
         },
         {
             name: "Suggest",
             id:"suggest",
-            url:"/api/v2/search/suggest?profile=false"
+            url:"/api/v2/search/suggest?profile=true"
         }
     ],
     queryTypes:[
@@ -38,15 +37,17 @@ export default Ember.Controller.extend({
              "LESS_THAN_EQUAL_TO",
              "GREATER_THAN",
              "GREATER_THAN_EQUAL_TO",
-//             "TERM",
+             "TERM"
 //             "TERMS".
     ],
-    aggregateTypes:["COUNT", "SUM", "AVERAGE", "CONTAINS", "STARTS_WITH", "ENDS_WITH"],
+    aggregateTypes:["COUNT", "SUM", "AVERAGE", "TERM", "CONTAINS", "STARTS_WITH", "ENDS_WITH"],
     aggregateSort:["VALUE_DESC", "VALUE_ASC", "COUNT_DESC", "COUNT_ASC"],
     aggregates:[],
     queryFilters:[],
     queryFilterOperators:["AND", "OR", "NOT"],
-    url: computed('searchType', function() {
+    profileQueryParameter: true,
+    returnFields:["guid"],
+    url: computed('searchType', 'profileQueryParameter', function() {
         let type = this.get('searchType');
         for(let x=0; x< this.searchTypes.length; x++){
             if(this.searchTypes[x].id === type){
@@ -65,6 +66,10 @@ export default Ember.Controller.extend({
             query.sortOrder = this.get("sort");
         }
 
+        if ((this.get("searchType") === "general_search") && this.profileQueryParameter) {
+            query.returnFields = this.get("returnFields");
+        }
+
         if(this.queryFilters.length > 0){
             query.query = this.queryFilters;
         }
@@ -81,10 +86,6 @@ export default Ember.Controller.extend({
             query.types.push("locations");
         }
 
-        if(this.get("getChats") === true){
-            query.types.push("messages");
-        }
-
         if(this.aggregates.length > 0){
             query.aggregations = this.aggregates;
         }
@@ -94,29 +95,17 @@ export default Ember.Controller.extend({
     queryObserver: observer('queryFilters', 'queryFilters.@each','queryFilters.@each.fields','queryFilters.@each.type',
                             'queryFilters.@each.operator','queryFilters.@each.value','queryFilters.@each.startValue',
                             'queryFilters.@each.endValue','sort','pageSize','pageNumber','getUsers','getGroups',
-                            'getLocations','getChats', 'aggregates', 'aggregates.@each', 'aggregates.@each.field', 'aggregates.@each.type',
-                            'aggregates.@each.name', 'aggregates.@each.value', function() {
+                            'getLocations', 'aggregates', 'aggregates.@each', 'aggregates.@each.field', 'aggregates.@each.type',
+                            'aggregates.@each.name', 'aggregates.@each.value', 'returnFields', 'profileQueryParameter', function() {
         this._calculateQueryJson();
         this._setAvailableFilterFields();
+        this._setSearchTypeUrl();
     }),
     searchTypeObserver: observer("searchType", function(){
         this.queryFilters.clear();
         if(this.get("searchType") === "suggest"){
             this.queryFilters.pushObject({});
-        }
-    }),
-    chatTypeObserver: observer("getChats", function(){
-        if(this.get("getChats") === true){
-            this.set("getLocations", false);
-            this.set("getUsers", false);
-            this.set("getGroups", false);
-        }
-    }),
-    nonChatTypeObserver: observer("getLocations","getUsers", "getGroups", function(){
-        if(this.get("getLocations") === true ||
-                this.get("getUsers") === true ||
-                this.get("getGroups") === true){
-            this.set("getChats", false);
+            this.aggregates.clear();
         }
     }),
     _setAvailableFilterFields(){
@@ -134,8 +123,7 @@ export default Ember.Controller.extend({
         let modelProperties = {
             "User":['id','name','department','email','title', 'username', 'presence', 'routingStatus', 'station', 'profileSkills'],
             "Group": ['id', 'name', 'description', 'dateModified', 'state', 'type', 'addresses', 'visibility'],
-            "Location": ['id', 'name', 'address', 'addressVerified', 'emergencyNumber', 'state'],
-            "Chat": ['body', 'created']
+            "Location": ['id', 'name', 'address', 'addressVerified', 'emergencyNumber', 'state']
         };
 
         if(this.get("getUsers") === true){
@@ -150,20 +138,36 @@ export default Ember.Controller.extend({
             getPropertiesFromModel(modelProperties["Location"]);
         }
 
-        if(this.get("getChats") === true){
-            getPropertiesFromModel(modelProperties["Chat"]);
-        }
-
         properties.sort();
 
         this.set("availableFilterFields", properties);
     },
+    _setSearchTypeUrl(){
+        let searchTypesItem0 = this.get("searchTypes").objectAt(0);
+        let searchTypesItem1 = this.get("searchTypes").objectAt(1);
+        if (this.profileQueryParameter) {
+            Ember.set(searchTypesItem0, "url", "/api/v2/search?profile=true");
+            Ember.set(searchTypesItem1, "url", "/api/v2/search/suggest?profile=true");
+        } else {
+            Ember.set(searchTypesItem0, "url", "/api/v2/search?profile=false");
+            Ember.set(searchTypesItem1, "url", "/api/v2/search/suggest?profile=false");
+        }
+    },
+    _setInitialFilter(){
+        this.queryFilters.pushObject({
+            type:"TERM",
+            fields:["name"],
+            operator: "AND",
+            value: "mySearchKeyword"
+        });
+    },
     queryJson:"",
     queryResult:null,
     init(){
+        this._setInitialFilter();
         this._calculateQueryJson();
         this.get("getUsers");
-        this.get("getChats");
+        this._setSearchTypeUrl();
         this._setAvailableFilterFields();
     },
     actions:{
@@ -211,11 +215,11 @@ export default Ember.Controller.extend({
                 this.queryFilters.pushObject({
                     type:"STARTS_WITH",
                     fields:[],
-                    operator: "OR"
+                    operator: "AND"
                 });
             }else{
                 this.queryFilters.pushObject({
-
+                    value: "mySuggestKeyword"
                 });
             }
         },
@@ -224,8 +228,9 @@ export default Ember.Controller.extend({
         },
         newAggregate(){
             this.aggregates.pushObject({
-                type:"CONTAINS",
-                field: this.get("availableFilterFields")[0]
+                type:"TERM",
+                field: this.get("availableFilterFields")[4],
+                name: "myAggregationBucketName"
             });
         },
         deleteAggregate(index){

--- a/app/controllers/search-query-builder.js
+++ b/app/controllers/search-query-builder.js
@@ -143,9 +143,9 @@ export default Ember.Controller.extend({
     _setSearchTypeUrls(){
         for (let x=0; x< this.searchTypes.length; x++){
             if (this.searchTypes[x].id === "general_search") {
-                this.set("url", "/api/v2/search?profile=" + this.profileQueryParameter)
-            } else {
-                this.set("url", "/api/v2/search/suggest?profile=" + this.profileQueryParameter)
+                this.searchTypes[x].url = "/api/v2/search?profile=" + this.profileQueryParameter;
+            } else if (this.searchTypes[x].id === "suggest") {
+                this.searchTypes[x].url = "/api/v2/search/suggest?profile=" + this.profileQueryParameter;
             }
         }
     },

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -78,11 +78,6 @@
                             {{input type="checkbox" checked=getLocations  }}
                             <label>Locations</label>
                         </div>
-                        <div class="control-label col-md-3">
-                            {{input type="checkbox" checked=getChats  }}
-                            <label>Chats</label>
-                        </div>
-
                     </div>
 
                 </div>
@@ -93,12 +88,46 @@
             <div class="panel-heading"><h3 class="panel-title panel-title-condensed">Order</h3></div>
             <div class="panel-body">
                 <p class="small text-muted">
-                    Result set sorting.
+                    Result set sorting. SCORE is the default.
                 </p>
                 {{select-box items=sortOptions selectedItem=sort class=form-control}}
             </div>
         </div>
         {{/if}}
+        
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title panel-title-condensed">Return Fields</h3>
+            </div>
+            <div class="panel-body">
+                <p class="small text-muted">
+                    The 'profile' query parameter will control the type of fields that can be returned in the response.
+                </p>
+                <div class='container-full'>
+                    <div class='row'>
+                        <div class="control-label col-md-3">
+                            {{input type="checkbox" checked=profileQueryParameter}}
+                            <label>Profile</label>
+                        </div>
+                    </div>
+                </div>
+                {{#if (eq searchType "general_search")}}
+                    {{#if profileQueryParameter}}
+                        <p class="small text-muted">Which fields to have returned in the response</p>
+                        <div class='filter-section filter-has-delete'>
+                            <form class="form form-horizontal form-horizontal-labels-left form-flex form-flex-1-col form-flex-has-delete">
+                                {{#if (eq searchType "general_search")}}
+                                    <div class="form-group">
+                                        <label class="control-label">Fields</label>
+                                            {{two-col-selector availableItems=availableFilterFields selectedItems=returnFields title=''}}
+                                    </div>
+                                {{/if}}
+                            </form>
+                        </div>
+                    {{/if}}
+                {{/if}}
+            </div>
+        </div>
 
         <div class="panel panel-default">
             <div class="panel-heading">
@@ -108,7 +137,7 @@
                 </button>
             </div>
             <div class="panel-body">
-                <p class="small text-muted">The search criteria.</p>
+                <p class="small text-muted">The search criteria. The default operator is AND.</p>
                 {{#each queryFilters as |queryFilter index|}}
                 <div class='filter-section filter-has-delete'>
 
@@ -176,6 +205,8 @@
                 {{/each}}
             </div>
         </div>
+
+        {{#if (eq searchType "general_search")}}
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title panel-title-condensed">Aggregates</h3>
@@ -212,13 +243,15 @@
                         {{select-box items=aggregateTypes selectedItem=aggregate.type class='capitalize'}}
 
                     </div>
+
+                    {{#unless (eq aggregate.type "TERM")}}
                     <div class="form-group">
                         <div class="control-label">
                             <label>Value</label>
                         </div>
                         {{input value=aggregate.value class='capitalize'}}
-
                     </div>
+                    {{/unless}}
 
 
                 </form>
@@ -226,6 +259,7 @@
                 {{/each}}
             </div>
         </div>
+        {{/if}}
 
 
 

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -163,8 +163,19 @@
                             <label>Type</label>
                         </div>
                         {{select-box items=queryTypes selectedItem=queryFilter.type class='capitalize'}}
-
                     </div>
+                    {{#if (eq queryFilter.type "TERM")}}
+                        <p>TERM is a good type for a general keyword search. For best results, use a lowercase search term.</p>
+                    {{else if (eq queryFilter.type "EXACT")}}
+                        <p>EXACT is a good choice when you know the exact value you want to find. For best results, use an exact case sensitive search term.</p>
+                    {{else if (eq queryFilter.type "CONTAINS")}}
+                        <p>CONTAINS is the equivalent of a wildcard style search like <pre>*keyword*</pre>. It is an expensive search, so there is a tradeoff for efficiency.</p>
+                    {{else if (eq queryFilter.type "STARTS_WITH")}}
+                        <p>STARTS_WITH is the equivalent of a wildcard style search like <pre>keyword*</pre>. It is an expensive search, so there is a tradeoff for efficiency.</p>
+                    {{else}}
+                        <p>This query type should only be used with a number value, in situations where it makes sense.</p>
+                    {{/if}}
+
 
                     <div class="form-group">
                         <label class="control-label">Fields</label>

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -229,6 +229,7 @@
         </div>
 
         {{#if (eq searchType "general_search")}}
+        {{#unless getChats}}
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title panel-title-condensed">Aggregates</h3>
@@ -281,6 +282,7 @@
                 {{/each}}
             </div>
         </div>
+        {{/unless}}
         {{/if}}
 
 

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -113,7 +113,7 @@
                 </div>
                 {{#if (eq searchType "general_search")}}
                     {{#if profileQueryParameter}}
-                        <p class="small text-muted">Which fields to have returned in the response</p>
+                        <p class="small text-muted">Specify which fields you would like returned in the response. This is a chance to optimize the size of your response and make it more efficient.</p>
                         <div class='filter-section filter-has-delete'>
                             <form class="form form-horizontal form-horizontal-labels-left form-flex form-flex-1-col form-flex-has-delete">
                                 {{#if (eq searchType "general_search")}}
@@ -139,7 +139,12 @@
                 {{/if}}
             </div>
             <div class="panel-body">
-                <p class="small text-muted">The search criteria. The default operator is AND if not provided.</p>
+                <p class="small text-muted">
+                    The search criteria. 
+                    {{#if (eq searchType "general_search")}}
+                        The default operator is AND if not provided.
+                    {{/if}}
+                </p>
                 {{#each queryFilters as |queryFilter index|}}
                 <div class='filter-section filter-has-delete'>
 

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -88,7 +88,7 @@
             <div class="panel-heading"><h3 class="panel-title panel-title-condensed">Order</h3></div>
             <div class="panel-body">
                 <p class="small text-muted">
-                    Result set sorting. SCORE is the default.
+                    Result set sorting. SCORE is the default if not provided.
                 </p>
                 {{select-box items=sortOptions selectedItem=sort class=form-control}}
             </div>
@@ -101,7 +101,7 @@
             </div>
             <div class="panel-body">
                 <p class="small text-muted">
-                    The 'profile' query parameter will control the type of fields that can be returned in the response.
+                    The profile query parameter defaults to true if not provided. It helps configure the set of fields that can be returned in the response. 
                 </p>
                 <div class='container-full'>
                     <div class='row'>
@@ -132,12 +132,14 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title panel-title-condensed">Filters</h3>
-                <button class='btn btn-link' {{action 'newQueryFilter'}} title="Add Filter">
-                    <i class="pc-moon pc-create-room"></i>
-                </button>
+                {{#if (eq searchType "general_search")}}
+                    <button class='btn btn-link' {{action 'newQueryFilter'}} title="Add Filter">
+                        <i class="pc-moon pc-create-room"></i>
+                    </button>
+                {{/if}}
             </div>
             <div class="panel-body">
-                <p class="small text-muted">The search criteria. The default operator is AND.</p>
+                <p class="small text-muted">The search criteria. The default operator is AND if not provided.</p>
                 {{#each queryFilters as |queryFilter index|}}
                 <div class='filter-section filter-has-delete'>
 

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -113,7 +113,7 @@
                 </div>
                 {{#if (eq searchType "general_search")}}
                     {{#if profileQueryParameter}}
-                        <p class="small text-muted">Specify which fields you would like returned in the response. This is a chance to optimize the size of your response and make it more efficient.</p>
+                        <p class="small text-muted">Specify which fields you would like returned in the response. This is a chance to optimize the size of your response and make it more efficient. You may benefit by only returning the guid and then making a bulk lookup API call to another service that is the home of record for the data.</p>
                         <div class='filter-section filter-has-delete'>
                             <form class="form form-horizontal form-horizontal-labels-left form-flex form-flex-1-col form-flex-has-delete">
                                 {{#if (eq searchType "general_search")}}
@@ -165,9 +165,9 @@
                         {{select-box items=queryTypes selectedItem=queryFilter.type class='capitalize'}}
                     </div>
                     {{#if (eq queryFilter.type "TERM")}}
-                        <p>TERM is a good type for a general keyword search. For best results, use a lowercase search term.</p>
+                        <p>TERM is a good type for a general keyword search. For best results, use a lowercase search keyword.</p>
                     {{else if (eq queryFilter.type "EXACT")}}
-                        <p>EXACT is a good choice when you know the exact value you want to find. For best results, use an exact case sensitive search term.</p>
+                        <p>EXACT is a good choice when you know the exact value you want to find. For best results, use an exact case sensitive search keyword.</p>
                     {{else if (eq queryFilter.type "CONTAINS")}}
                         <p>CONTAINS is the equivalent of a wildcard style search like <pre>*keyword*</pre>. It is an expensive search, so there is a tradeoff for efficiency.</p>
                     {{else if (eq queryFilter.type "STARTS_WITH")}}

--- a/app/templates/search-query-builder.hbs
+++ b/app/templates/search-query-builder.hbs
@@ -78,6 +78,10 @@
                             {{input type="checkbox" checked=getLocations  }}
                             <label>Locations</label>
                         </div>
+                        <div class="control-label col-md-3">
+                            {{input type="checkbox" checked=getChats  }}
+                            <label>Chats</label>
+                        </div>
                     </div>
 
                 </div>


### PR DESCRIPTION
Goal for this PR was to make a few minor adjustments to the search query builder:

- make 'profile' query parameter able to be toggled on and off
- add 'returnFields' property available on Search queries (not suggest) where profile query parameter is set to true
- don't show aggregations options for suggest queries
- show a default search criteria on page load
- change default operator for search criteria to AND
- change default sort to SCORE
- add TERM aggregation type
- add TERM query type
- only allow one search criteria for suggest queries
- add a few useful text tips when user switches to different query types

Here is a gif of the search query builder in action with these changes:

![search-query-builder-pr-demo](https://cloud.githubusercontent.com/assets/2000350/20680795/924e02e8-b56e-11e6-8ff2-7bf3b35de563.gif)

