### PR TITLE
CA-4074: Don't minify the vendorjs file

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,6 +9,11 @@ module.exports = function(defaults) {
         autoprefixer: {
             browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1']
         },
+        minifyJS: {
+          options: {
+            exclude: ["**/vendor.js"]
+          }
+        },
         replace: {
             files: ['index.html'],
             patterns: [{


### PR DESCRIPTION
no reason to minify the vendor js file just increases the run time of the production build.