### PR TITLE
Add survey filter to conversation detail record query

### DIFF
--- a/app/components/conversation-detail-query.js
+++ b/app/components/conversation-detail-query.js
@@ -5,6 +5,7 @@ export default Ember.Component.extend({
     interval: null,
     segmentFilters: [],
     evaluationFilters: [],
+    surveyFilters: [],
     conversationFilters: [],
 
     order: "asc",
@@ -40,6 +41,10 @@ export default Ember.Component.extend({
 
         if(this.evaluationFilters.length > 0){
             query.evaluationFilters = this.get("evaluationFilters");
+        }
+
+        if(this.surveyFilters.length > 0){
+          query.surveyFilters = this.get("surveyFilters");
         }
 
         if(this.aggregations.length > 0){
@@ -96,6 +101,21 @@ export default Ember.Component.extend({
         deleteEvaluationFilter:function(index){
             this.evaluationFilters.removeAt(index);
             this.set("queryJson", JSON.stringify(this._computeValue(), null, " "));
+        },
+        newSurveyFilter: function(){
+          this.surveyFilters.addObject({
+            type: "or",
+            clauses: [],
+            predicates: []
+          });
+        },
+        updateSurveyFilter: function(index,filter){
+          this.surveyFilters[index] = filter;
+          this.set("queryJson", JSON.stringify(this._computeValue(), null, " "));
+        },
+        deleteSurveyFilter:function(index){
+          this.evaluationFilters.removeAt(index);
+          this.set("queryJson", JSON.stringify(this._computeValue(), null, " "));
         },
         newConversationFilter: function(){
             this.conversationFilters.addObject({

--- a/app/templates/components/conversation-detail-query.hbs
+++ b/app/templates/components/conversation-detail-query.hbs
@@ -91,6 +91,29 @@
 </div>
 
 <div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title panel-title-condensed">Survey Filters</h3>
+    <button class='btn btn-link btn-sm' {{action 'newSurveyFilter'}} title="Add Filter">
+      <i class="pc-moon pc-create-room"></i>
+    </button>
+  </div>
+  <div class="panel-body">
+    <p class="small text-muted">
+      Filters that target quality management survey-level data.
+    </p>
+
+    {{#each surveyFilters as |surveyFilter index|}}
+      <div class="filter-section filter-has-delete">
+        {{analytics-query-filter filter=surveyFilter showDefaultHeader=false index=index updateFilter=(action 'updateSurveyFilter')}}
+        <button class='btn btn-link btn-delete-filter' {{action 'deleteSurveyFilter' index}}>
+          <i class="ion-close-round" aria-hidden="true"></i>
+        </button>
+      </div>
+    {{/each}}
+  </div>
+</div>
+
+<div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title panel-title-condensed">Segment Filters</h3>
         <button class='btn btn-link btn-sm' {{action 'newSegmentFilter'}} title="Add Filter">


### PR DESCRIPTION
This adds a survey filter for the conversation detail record query in the Analytics Query Builder.

It mimics exactly the filter for evaluations.