### PR TITLE
DEVCTR-24 Analytics filter value input control hidden initially on clause predicate

### DIFF
--- a/app/components/analytics-query-predicate.js
+++ b/app/components/analytics-query-predicate.js
@@ -9,6 +9,7 @@ export default Ember.Component.extend({
 	userService: Ember.inject.service(),
 	presenceService: Ember.inject.service(),
 	query: "default",
+	isDevOrStaging: !window.location.hostname.includes('purecloud'),
 
 	//TODO: support queue ids, user Ids,
 	init: function() {

--- a/app/templates/components/analytics-query-predicate.hbs
+++ b/app/templates/components/analytics-query-predicate.hbs
@@ -30,6 +30,10 @@
     </div>
      <div class="form-group form-group-offset">
             <label class="control-label">Value</label>
+        {{#if isDevOrStaging}}
+            {{log "selectedType: " selectedType}}
+            {{log "selectedOperator: " selectedOperator}}
+        {{/if}}
         {{#if (eq selectedType 'metric')}}
             {{input class='form-control' value=value}}
         {{else}}
@@ -50,7 +54,9 @@
                 {{else}}
                 {{input class='form-control' value=value}}
                 {{/if}}
-            
+
+            {{else}}
+            {{input class='form-control' value=value}}
             {{/if}}
         {{/if}}
     </div>


### PR DESCRIPTION
This issue only when hosted remotely, i.e. not in development.
I've put in a potential fix and some debug logging.