### PR TITLE
No jira fix envs

### DIFF
--- a/app/routes/api-explorer.js
+++ b/app/routes/api-explorer.js
@@ -36,9 +36,11 @@ export default Ember.Route.extend({
 		}
 
 		let purecloudEnvironment = purecloudEnvironmentTld();
+		const match = /^developer\.(.+)$/i.exec(window.location.hostname);
+		let siteHost = match ? match[1] : purecloudEnvironment;
 
 		let swaggerUrl = `https://api.${purecloudEnvironment}/api/v2/docs/swagger`;
-		swaggerUrl = `/swagger-schema/publicapi-v2-latest.json`;
+		// swaggerUrl = '/swagger-schema/publicapi-v2-latest.json';
 
 		let swagger =
 			`openApiUrl=${swaggerUrl}&host=api.${purecloudEnvironment}&shareUrl=${window.location.origin}` +
@@ -50,16 +52,16 @@ export default Ember.Route.extend({
 			search += '&' + swagger;
 		}
 
-		let openApiExplorerUrl = `https://developer.${purecloudEnvironment}/openapi-explorer/index.html`;
+		let openApiExplorerUrl = `https://developer.${siteHost}/openapi-explorer/index.html`;
 
-		if (purecloudEnvironment === 'aps1.pure.cloud') {
+		if (siteHost === 'aps1.pure.cloud') {
 			//Mumbai region redirect to useast-1
 			openApiExplorerUrl = `https://developer.mypurecloud.com/openapi-explorer/index.html`;
 		}
 
-		if (purecloudEnvironment === 'ininsca.com') {
+		if (siteHost === 'ininsca.com') {
 			//need to special case here
-			openApiExplorerUrl = `https://apps.${purecloudEnvironment}/openapi-explorer/`;
+			openApiExplorerUrl = `https://apps.${siteHost}/openapi-explorer/`;
 		}
 
 		//openApiExplorerUrl = 'http://localhost:8081/';

--- a/app/routes/api-explorer.js
+++ b/app/routes/api-explorer.js
@@ -37,10 +37,20 @@ export default Ember.Route.extend({
 
 		let purecloudEnvironment = purecloudEnvironmentTld();
 		const match = /^developer\.(.+)$/i.exec(window.location.hostname);
-		let siteHost = match ? match[1] : purecloudEnvironment;
+		let siteHost = match ? match[1] : 'genesys.cloud';
 
+		// Build swagger url
 		let swaggerUrl = `https://api.${purecloudEnvironment}/api/v2/docs/swagger`;
-		// swaggerUrl = '/swagger-schema/publicapi-v2-latest.json';
+
+		// Determine override
+		var query = window.location.search.substring(1);
+		var vars = query.split('&');
+		for (var i = 0; i < vars.length; i++) {
+			var pair = vars[i].split('=');
+			if (decodeURIComponent(pair[0] || '').toLowerCase() === 'swaggeroverride') {
+				swaggerUrl = decodeURIComponent(pair[1]);
+			}
+		}
 
 		let swagger =
 			`openApiUrl=${swaggerUrl}&host=api.${purecloudEnvironment}&shareUrl=${window.location.origin}` +
@@ -54,17 +64,10 @@ export default Ember.Route.extend({
 
 		let openApiExplorerUrl = `https://developer.${siteHost}/openapi-explorer/index.html`;
 
-		if (siteHost === 'aps1.pure.cloud') {
-			//Mumbai region redirect to useast-1
-			openApiExplorerUrl = `https://developer.mypurecloud.com/openapi-explorer/index.html`;
-		}
-
 		if (siteHost === 'ininsca.com') {
 			//need to special case here
 			openApiExplorerUrl = `https://apps.${siteHost}/openapi-explorer/`;
 		}
-
-		//openApiExplorerUrl = 'http://localhost:8081/';
 
 		return `${openApiExplorerUrl}${search}#token_type=bearer&access_token=` + platformClient.ApiClient.instance.authData.accessToken;
 	},


### PR DESCRIPTION
This change separates the logic that determines where to find the swagger definition from the logic that determines the host for embedded openapi explorer. It also allows for a query parameter to override where to load the swagger definition. These changes facilitate hosting the dev tools from a single domain but loading swagger from the environment the user is authorized for.