### PR TITLE
Fixes sample code snippet to set the current status

### DIFF
--- a/app/utils/sample-code.js
+++ b/app/utils/sample-code.js
@@ -62,7 +62,7 @@ function setPresence(presenceId){
   };
 
   // Patch presence
-  presenceApi.getUserPresence(userId, 'PURECLOUD', newPresence);
+  presenceApi.patchUserPresence(userId, 'PURECLOUD', newPresence);
 }
 
 //Start by getting all the presence definitions in the system


### PR DESCRIPTION
While going through some training, I noticed this piece of code was not working correctly (the status was not getting set correctly). Following the suggestion from the comment above the line, setting this to `patch` fixed the issue and the status was able to be toggled.